### PR TITLE
Non-standard Extensions to Lua in mehtap

### DIFF
--- a/src/mehtap/ast_nodes.py
+++ b/src/mehtap/ast_nodes.py
@@ -643,6 +643,8 @@ class BinaryOperator(enum.Enum):
     GE = ">="
     EQ = "=="
     NE = "~="
+    NE_C = "!="
+    NE_SQL = "<>"
     BIT_OR = "|"
     BIT_XOR = "~"
     BIT_AND = "&"
@@ -667,6 +669,8 @@ binary_operator_functions: dict[
     BinaryOperator.GE: m_operations.rel_ge,
     BinaryOperator.EQ: m_operations.rel_eq,
     BinaryOperator.NE: m_operations.rel_ne,
+    BinaryOperator.NE_C: m_operations.rel_ne,
+    BinaryOperator.NE_SQL: m_operations.rel_ne,
     BinaryOperator.BIT_OR: m_operations.bitwise_or,
     BinaryOperator.BIT_XOR: m_operations.bitwise_xor,
     BinaryOperator.BIT_AND: m_operations.bitwise_and,

--- a/src/mehtap/ast_transformer.py
+++ b/src/mehtap/ast_transformer.py
@@ -350,6 +350,10 @@ class LuaTransformer(lark.Transformer):
         return nodes.EmptyStatement()
 
     @staticmethod
+    def stat_break_fancy(BREAK, digits: nodes.Terminal):
+        return nodes.Break(int(digits.text))
+
+    @staticmethod
     def stat_break(BREAK):
         return nodes.Break()
 

--- a/src/mehtap/ast_transformer.py
+++ b/src/mehtap/ast_transformer.py
@@ -469,6 +469,74 @@ class LuaTransformer(lark.Transformer):
         )
 
     @staticmethod
+    def list_compr_numeric(
+        exp: nodes.Expression,
+        FOR,
+        name: nodes.Name,
+        start,
+        stop,
+        step,
+    ):
+        return nodes.NumericComprehension(
+            key_exp=None,
+            value_exp=exp,
+            name=name,
+            start=start,
+            stop=stop,
+            step=step,
+        )
+
+    @staticmethod
+    def dict_compr_numeric(
+        key_exp: nodes.Expression,
+        value_exp: nodes.Expression,
+        FOR,
+        name: nodes.Name,
+        start,
+        stop,
+        step,
+    ):
+        return nodes.NumericComprehension(
+            key_exp=key_exp,
+            value_exp=value_exp,
+            name=name,
+            start=start,
+            stop=stop,
+            step=step,
+        )
+
+    @staticmethod
+    def list_compr_generic(
+        exp: nodes.Expression,
+        FOR,
+        namelist,
+        IN,
+        explist,
+    ):
+        return nodes.GenericComprehension(
+            key_exp=None,
+            value_exp=exp,
+            names=namelist,
+            exprs=explist,
+        )
+
+    @staticmethod
+    def dict_compr_generic(
+        key_exp: nodes.Expression,
+        value_exp: nodes.Expression,
+        FOR,
+        namelist,
+        IN,
+        explist,
+    ):
+        return nodes.GenericComprehension(
+            key_exp=key_exp,
+            value_exp=value_exp,
+            names=namelist,
+            exprs=explist,
+        )
+
+    @staticmethod
     def stat_forin(FOR, namelist, IN, explist, DO, block, END):
         return nodes.ForIn(
             names=namelist,

--- a/src/mehtap/ast_transformer.py
+++ b/src/mehtap/ast_transformer.py
@@ -405,6 +405,23 @@ class LuaTransformer(lark.Transformer):
         return nodes.FuncDef(body=funcbody)
 
     @staticmethod
+    def exp_lambda(parlist, exp: nodes.Expression) -> nodes.FuncBody:
+        block = nodes.Block(
+            statements=tuple(),
+            return_statement=nodes.ReturnStatement(values=(exp,)),
+        )
+        if parlist is None:
+            return nodes.FuncBody(
+                params=tuple(),
+                body=block,
+            )
+        return nodes.FuncBody(
+            params=parlist.names,
+            body=block,
+            vararg=parlist.vararg,
+        )
+
+    @staticmethod
     def funcname(*names) -> nodes.FuncName:
         method = names[-1]
         if method is not None:

--- a/src/mehtap/ast_transformer.py
+++ b/src/mehtap/ast_transformer.py
@@ -595,6 +595,21 @@ class LuaTransformer(lark.Transformer):
         )
 
     @staticmethod
+    def stat_with(
+        WITH,
+        namelist,
+        explist,
+        DO,
+        block,
+        END
+    ):
+        return nodes.ContextManagerEntry(
+            explist=explist,
+            namelist=namelist,
+            block=block
+        )
+
+    @staticmethod
     def literalstring(terminal: nodes.Terminal) -> nodes.LiteralString:
         return nodes.LiteralString(text=terminal)
 

--- a/src/mehtap/ast_transformer.py
+++ b/src/mehtap/ast_transformer.py
@@ -358,6 +358,10 @@ class LuaTransformer(lark.Transformer):
         return nodes.Break()
 
     @staticmethod
+    def stat_continue(CONTINUE):
+        return nodes.Continue()
+
+    @staticmethod
     def stat_goto(GOTO, name: nodes.Name):
         return nodes.Goto(name=name)
 

--- a/src/mehtap/control_structures.py
+++ b/src/mehtap/control_structures.py
@@ -64,7 +64,7 @@ class FlowControlException(BaseException):
 
 @attrs.define(slots=True)
 class BreakException(FlowControlException):
-    pass
+    level: int = 1
 
 
 @attrs.define(slots=True)

--- a/src/mehtap/control_structures.py
+++ b/src/mehtap/control_structures.py
@@ -63,6 +63,11 @@ class FlowControlException(BaseException):
 
 
 @attrs.define(slots=True)
+class ContinueException(FlowControlException):
+    pass
+
+
+@attrs.define(slots=True)
 class BreakException(FlowControlException):
     level: int = 1
 

--- a/src/mehtap/lua.lark
+++ b/src/mehtap/lua.lark
@@ -6,6 +6,7 @@ block: stat* [retstat]
      | varlist "=" explist -> stat_assignment
      | functioncall
      | label
+     | CONTINUE -> stat_continue
      | BREAK -> stat_break
      | BREAK digits -> stat_break_fancy
      | GOTO NAME -> stat_goto
@@ -124,6 +125,7 @@ THEN: "then"
 TRUE: "true"
 UNTIL: "until"
 WHILE: "while"
+CONTINUE: "continue"
 
 %import common.WS
 %ignore WS

--- a/src/mehtap/lua.lark
+++ b/src/mehtap/lua.lark
@@ -7,6 +7,7 @@ block: stat* [retstat]
      | functioncall
      | label
      | BREAK -> stat_break
+     | BREAK digits -> stat_break_fancy
      | GOTO NAME -> stat_goto
      | DO block END -> stat_do
      | WHILE exp DO block END -> stat_while

--- a/src/mehtap/lua.lark
+++ b/src/mehtap/lua.lark
@@ -54,6 +54,7 @@ explist: explist_entry ("," explist_entry)*
     | "|" [parlist] "|" exp -> exp_lambda
     | "(" [parlist] ")" "=>" exp -> exp_lambda
     | tableconstructor
+    | compr
     | exp "or" exp -> exp_logical_or
     | exp "and" exp -> exp_logical_and
     | exp cmp_op exp -> exp_cmp
@@ -75,6 +76,7 @@ functioncall: prefixexp args -> functioncall_regular
             | prefixexp ":" NAME args -> functioncall_method
 args: "(" [explist] ")" -> args_list
     | tableconstructor -> args_value
+    | compr -> args_value
     | literalstring -> args_value
 
 funcbody: "(" [parlist] ")" block END
@@ -88,6 +90,11 @@ field: "[" exp "]" "=" exp -> field_with_key
      | NAME "=" exp -> field_with_key
      | exp -> field_counter_key
 fieldsep: "," | ";"
+
+compr: "{" exp FOR NAME "=" exp "," exp ["," exp] "}"                 -> list_compr_numeric
+     | "{" exp FOR namelist IN explist "}"                            -> list_compr_generic
+     | "{" "[" exp "]" "=" exp FOR NAME "=" exp "," exp ["," exp] "}" -> dict_compr_numeric
+     | "{" "[" exp "]" "=" exp FOR namelist IN explist "}"            -> dict_compr_generic
 
 !cmp_op: "<" | "<=" | ">" | ">=" | "==" | "~=" | "!=" | "<>"
 !shift_op: ">>" | "<<"

--- a/src/mehtap/lua.lark
+++ b/src/mehtap/lua.lark
@@ -87,7 +87,7 @@ field: "[" exp "]" "=" exp -> field_with_key
      | exp -> field_counter_key
 fieldsep: "," | ";"
 
-!cmp_op: "<" | "<=" | ">" | ">=" | "==" | "~="
+!cmp_op: "<" | "<=" | ">" | ">=" | "==" | "~=" | "!=" | "<>"
 !shift_op: ">>" | "<<"
 !sumop: "+" | "-"
 !productop: "*" | "/" | "//" | "%"

--- a/src/mehtap/lua.lark
+++ b/src/mehtap/lua.lark
@@ -19,6 +19,7 @@ block: stat* [retstat]
      | FUNCTION funcname funcbody -> stat_function
      | LOCAL FUNCTION NAME funcbody -> stat_localfunction
      | LOCAL attnamelist ["=" explist] -> stat_localassignment
+     | WITH namelist "=" explist DO block END -> stat_with
 
 stat_if: "if" exp "then" block elseif* [else] "end"
 elseif: "elseif" exp "then" block
@@ -135,6 +136,7 @@ THEN: "then"
 TRUE: "true"
 UNTIL: "until"
 WHILE: "while"
+WITH: "with"
 
 %import common.WS
 %ignore WS

--- a/src/mehtap/lua.lark
+++ b/src/mehtap/lua.lark
@@ -114,6 +114,7 @@ numeral_dec: digits ["." digits] [("e" | "E") [sign] digits]
 
 AND: "and"
 BREAK: "break"
+CONTINUE: "continue"
 DO: "do"
 ELSE: "else"
 ELSEIF: "elseif"
@@ -134,7 +135,6 @@ THEN: "then"
 TRUE: "true"
 UNTIL: "until"
 WHILE: "while"
-CONTINUE: "continue"
 
 %import common.WS
 %ignore WS

--- a/src/mehtap/lua.lark
+++ b/src/mehtap/lua.lark
@@ -51,6 +51,8 @@ explist: explist_entry ("," explist_entry)*
     | literalstring
     | "..." -> exp_vararg
     | "function" funcbody -> exp_functiondef
+    | "|" [parlist] "|" exp -> exp_lambda
+    | "(" [parlist] ")" "=>" exp -> exp_lambda
     | tableconstructor
     | exp "or" exp -> exp_logical_or
     | exp "and" exp -> exp_logical_and


### PR DESCRIPTION
The "nonstandard" branch includes quality-of-life features inspired by other languages and other Lua implementations.

Current extensions:
- `break N` statements to break out of N loops
- `continue` statements
- C and SQL-style inequality `a != b` and `a <> b`
- Lambda functions in the style of `|x, y| x+y` and `(x, y) => x+y`
- Python style comprehensions `{x for x = 1, 5}` and `{[-x]=x for x = 1, 5}` (and their generic for equivalents)
- Context managers (`with a, b = c, d do ... end` syntax with `__enter` and `__exit` metamethods)
