### PR TITLE
GitHub actions/setup-python, allow-prereleases: true

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
                 with:
                     python-version: ${{ matrix.python-version }}
                     cache: "pip"
+                    allow-prereleases: true
             -   name: Install Poetry
                 run: |
                     python -m pip install --upgrade pip


### PR DESCRIPTION
Let's test on Python 3.15 beta 3...
https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases

---
Unrelated failure:
> [CodacyCoverageReporter] Invalid configuration: Empty argument for --project-token